### PR TITLE
Fixed an error

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -119,8 +119,8 @@ Par exemple, pour créer une image à partir de données recues par une requête
 pouvez utiliser le code suivant:
 
     >>> from PIL import Image
-    >>> from StringIO import StringIO
-    >>> i = Image.open(StringIO(r.content))
+    >>> from io import BytesIO
+    >>> i = Image.open(BytesIO(r.content))
 
 
 Réponse JSON


### PR DESCRIPTION
If you use StringIO will get an error: initial_value must be str or None, not bytes.
The English version is BytesIO.
