### PR TITLE
Fix doc for the JSON response chapter

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -129,11 +129,11 @@ Réponse JSON
 Si vous devez travailler avec des données JSON, Requests dispose dun décodeur intégré::
 
     >>> import requests
-    >>> r = requests.get('https://github.com/timeline.json')
-    >>> r.json
-    [{u'repository': {u'open_issues': 0, u'url': 'https://github.com/...
+    >>> r = requests.get('https://api.github.com/repos/psf/requests')
+    >>> r.json()
+    {'id': 1362490, 'node_id': 'MDEwOlJlcG9zaXRvcnkxMzYyNDkw', 'name': 'requests',...
 
-Si jamais le décodage échoue, ``r.json`` renverra simplement ``None``.
+Si jamais le décodage échoue, ``r.json()`` renverra simplement ``None``.
 
 
 Réponse brute


### PR DESCRIPTION
- use `r.json()` instead of `r.json`, which doesn't work
- update example api endpoint, since the last one (`https://github.com/timeline.json`) [is now deprecated](https://github.blog/2012-06-12-github-api-v2-end-of-life/).